### PR TITLE
Disabling Overlay Cache

### DIFF
--- a/application/notebook_generator.py
+++ b/application/notebook_generator.py
@@ -63,7 +63,7 @@ def create_jnb(hdlgen_prj, add_to_log_box, force_gen=False):
     py_file_contents += "\nfrom IPython.display import SVG, display"
     py_file_contents += "\nfrom ipywidgets import GridspecLayout, Output, HBox"
     py_file_contents += "\nfrom ipywidgets import Button, Layout, jslink, IntText, IntSlider"
-    py_file_contents += "\nfrom pynq import Overlay"
+    py_file_contents += "\nfrom pynq import Overlay, PL"
     py_file_contents += "\nimport pandas as pd"
     py_file_contents += "\nimport time"
     py_file_contents += "\nimport os"
@@ -256,6 +256,7 @@ def create_jnb(hdlgen_prj, add_to_log_box, force_gen=False):
     # Python Set Up Code Block
     # Import Overlay
     py_file_contents += "\n\n# Import Overlay"
+    py_file_contents += "\n\nPL.reset()"
     py_file_contents += f"\n{compName} = Overlay(\"{compName}.bit\")"
 
     # This portion needs to be remodelled to support >32 bit signals which have been divided.


### PR DESCRIPTION
For some reason, Jupyter Notebooks running on PYNQ boards have a strange behaviour where they cache .bit overlays. The picture below shows how I'm trying to run a Mux2_1 with a `Mux2_1.bit` overlay but the notebook is trying (and failing) to use a cached `CB4CLED.bit` overlay
![image](https://github.com/user-attachments/assets/3090d9f7-371d-4c0c-87ac-b5aab4c3c270)

This problem has been reported [here ](https://github.com/Xilinx/PYNQ/issues/1409#issuecomment-1327183742) with a given fix

```python
from pynq import PL
PL.reset()
```